### PR TITLE
Add exception handling for setting OpenAI API key

### DIFF
--- a/magic_commit/__main__.py
+++ b/magic_commit/__main__.py
@@ -39,7 +39,13 @@ def main() -> None:
     # Decide what to do based on the arguments
     args = parser.parse_args()
     if args.key:
-        set_api_key(args.key, log)
+        try:
+            set_api_key(args.key)
+            print("🔑 OpenAI API key set!")
+        except OSError as e:
+            print("Unable to set OpenAI API key.")
+        except Exception as e:
+            print(e)
 
     else:
         directory = args.directory or "."  # Default to the current directory


### PR DESCRIPTION
Modified the `main` function in `magic_commit/__main__.py` to include exception handling when setting the OpenAI API key. If setting the key raises an `OSError`, a message is printed indicating that the key could not be set. Any other exception is caught and printed for debugging purposes. Additionally, a success message is printed if the key is set successfully.

This change improves the robustness of the code by gracefully handling potential errors during the API key setup process.